### PR TITLE
Fix CSV export functionality for all data types

### DIFF
--- a/lib/api/devicestatus/index.js
+++ b/lib/api/devicestatus/index.js
@@ -90,7 +90,8 @@ function configure (app, wares, ctx, env) {
     }
 
     const inMemoryData = ctx.cache.devicestatus ? ctx.cache.devicestatus : [];
-    const canServeFromMemory = inMemoryData.length >= q.count && Object.keys(q).length == 1 ? true : false;
+    // Only use in-memory cache if count is reasonable (not attempting a large export)
+    const canServeFromMemory = inMemoryData.length >= q.count && Object.keys(q).length == 1 && q.count < 10000 ? true : false;
 
     var results;
     if (canServeFromMemory) {

--- a/lib/api/entries/index.js
+++ b/lib/api/entries/index.js
@@ -200,11 +200,14 @@ function configure (app, wares, ctx, env) {
       var replacer = function(key, value) {
         return value === null ? '' : value
       }
-      var csv = outputdata.map(function(row) {
+      // Create header row
+      var csv = [fields.join(separator)];
+      // Add data rows
+      csv = csv.concat(outputdata.map(function(row) {
         return fields.map(function(fieldName) {
           return JSON.stringify(row[fieldName], replacer)
         }).join(separator)
-      });
+      }));
       return csv.join('\r\n');
     }
 
@@ -474,7 +477,8 @@ function configure (app, wares, ctx, env) {
       inMemoryCollection = ctx.cache.getData('entries');
     }
 
-    if (inMemoryPossible && query.count <= inMemoryCollection.length) {
+    // Only use in-memory cache if count is reasonable (not attempting a large export)
+    if (inMemoryPossible && query.count <= inMemoryCollection.length && query.count < 10000) {
       res.entries = _.cloneDeep(_.take(inMemoryCollection,query.count));
 
       for (let i = 0; i < res.entries.length; i++) {

--- a/lib/api/food/index.js
+++ b/lib/api/food/index.js
@@ -68,6 +68,11 @@ function configure (app, wares, ctx) {
           return res.sendJSONStatus(res, consts.HTTP_INTERNAL_ERROR, 'Mongo Error', err);
         }
         
+        // Ensure we have results or return empty array
+        if (!results) {
+          results = [];
+        }
+        
         return res.format({
           'text/plain': function() {
             var output = formatWithSeparator(results, "\t");

--- a/lib/api/profile/index.js
+++ b/lib/api/profile/index.js
@@ -105,13 +105,8 @@ function configure (app, wares, ctx) {
     // List profiles available
     api.get('/profiles/', query_models);
 
-    // List profiles available
-    api.get('/profile/', function(req, res) {
-        const limit = req.query && req.query.count ? Number(req.query.count) : consts.PROFILES_DEFAULT_COUNT;
-        ctx.profile.list(function (err, attribute) {
-            return res.json(attribute);
-        }, limit);
-    });
+    // List profiles available (supports CSV format via query_models)
+    api.get('/profile/', query_models);
 
     // List current active record (in current state LAST record is current active)
     api.get('/profile/current', function(req, res) {

--- a/lib/api/treatments/index.js
+++ b/lib/api/treatments/index.js
@@ -131,7 +131,8 @@ res.json(results);
       }
 
     const inMemoryData = ctx.cache.treatments;
-    const canServeFromMemory = inMemoryData && inMemoryData.length >= query.count && Object.keys(query).length == 1 ? true : false;
+    // Only use in-memory cache if count is reasonable (not attempting a large export)
+    const canServeFromMemory = inMemoryData && inMemoryData.length >= query.count && Object.keys(query).length == 1 && query.count < 10000 ? true : false;
 
     if (canServeFromMemory) {
       serveTreatments(req, res, null, _take(inMemoryData,query.count));


### PR DESCRIPTION
Fixed multiple issues with CSV exports:

1. Entries CSV export:
   - Added header row to CSV output (dateString, date, sgv, direction, device)
   - Fixed incomplete data export by bypassing in-memory cache for large exports (count >= 10000)
   - Database is now queried directly for large exports to ensure all rows are included

2. Treatments CSV export:
   - Fixed incomplete data export by bypassing in-memory cache for large exports (count >= 10000)
   - Database is now queried directly for large exports to ensure all rows are included

3. Profile CSV export:
   - Changed /profile/ endpoint to use query_models function to support CSV format
   - Previously only returned JSON, now properly returns CSV when .csv extension is used

4. Devicestatus CSV export:
   - Fixed blank output by bypassing in-memory cache for large exports (count >= 10000)
   - Database is now queried directly for large exports to generate proper CSV with all data

5. Food CSV export:
   - Added null check to ensure empty array is returned when no results
   - Improved error handling for blank output scenarios

All exports now properly query the database when count parameter is 10000 or higher, ensuring complete data export rather than being limited by in-memory cache size.